### PR TITLE
Fix IBSCOM_MCS_BASE_ADDR value

### DIFF
--- a/garrison.xml
+++ b/garrison.xml
@@ -8411,8 +8411,7 @@
     </attribute>
     <attribute>
         <id>IBSCOM_MCS_BASE_ADDR</id>
-        <default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000
-            </default>
+        <default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000</default>
     </attribute>
     <attribute>
         <id>MODEL</id>
@@ -8459,8 +8458,7 @@
     </attribute>
     <attribute>
         <id>IBSCOM_MCS_BASE_ADDR</id>
-        <default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000
-            </default>
+        <default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000</default>
     </attribute>
     <attribute>
         <id>MODEL</id>
@@ -8507,8 +8505,7 @@
     </attribute>
     <attribute>
         <id>IBSCOM_MCS_BASE_ADDR</id>
-        <default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000
-            </default>
+        <default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000</default>
     </attribute>
     <attribute>
         <id>MODEL</id>
@@ -8555,8 +8552,7 @@
     </attribute>
     <attribute>
         <id>IBSCOM_MCS_BASE_ADDR</id>
-        <default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000
-            </default>
+        <default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000</default>
     </attribute>
     <attribute>
         <id>MODEL</id>
@@ -9524,8 +9520,7 @@
     </attribute>
     <attribute>
         <id>IBSCOM_MCS_BASE_ADDR</id>
-        <default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000
-            </default>
+        <default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000</default>
     </attribute>
     <attribute>
         <id>MODEL</id>
@@ -9572,8 +9567,7 @@
     </attribute>
     <attribute>
         <id>IBSCOM_MCS_BASE_ADDR</id>
-        <default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000
-            </default>
+        <default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000</default>
     </attribute>
     <attribute>
         <id>MODEL</id>
@@ -9620,8 +9614,7 @@
     </attribute>
     <attribute>
         <id>IBSCOM_MCS_BASE_ADDR</id>
-        <default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000
-            </default>
+        <default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000</default>
     </attribute>
     <attribute>
         <id>MODEL</id>
@@ -9668,8 +9661,7 @@
     </attribute>
     <attribute>
         <id>IBSCOM_MCS_BASE_ADDR</id>
-        <default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000
-            </default>
+        <default>0x0003E00000000000,0x40000000000,0x10000000000,0x2000000000</default>
     </attribute>
     <attribute>
         <id>MODEL</id>


### PR DESCRIPTION
The whitespace was tripping up the xmltohb.pl script.

Signed-off-by: Joel Stanley <joel@jms.id.au>